### PR TITLE
[Qwen2.5] fix ld problem: can't find -lbmrt -lbmlib

### DIFF
--- a/models/Qwen2_5/support/lib_pcie/libbmlib.so
+++ b/models/Qwen2_5/support/lib_pcie/libbmlib.so
@@ -1,0 +1,1 @@
+libbmlib.so.0

--- a/models/Qwen2_5/support/lib_pcie/libbmrt.so
+++ b/models/Qwen2_5/support/lib_pcie/libbmrt.so
@@ -1,0 +1,1 @@
+libbmrt.so.1.0

--- a/models/Qwen2_5/support/lib_soc/libbmlib.so
+++ b/models/Qwen2_5/support/lib_soc/libbmlib.so
@@ -1,0 +1,1 @@
+libbmlib.so.0

--- a/models/Qwen2_5/support/lib_soc/libbmrt.so
+++ b/models/Qwen2_5/support/lib_soc/libbmrt.so
@@ -1,0 +1,1 @@
+libbmrt.so.1.0


### PR DESCRIPTION
add libbmlib.so libbmrt.so in models/Qwen2_5/support/lib_soc models/Qwen2_5/upport/lib_pcie