### PR TITLE
feat: Falcon-Perception bf16 FlexAttentionOp + device-side embedding

### DIFF
--- a/models/Falcon-Perception/README.md
+++ b/models/Falcon-Perception/README.md
@@ -4,17 +4,23 @@ This project deploys the vision segmentation large model [Falcon-Perception](htt
 
 The model supports referring segmentation in images: given a natural language description plus an image, it outputs the target's normalized bounding box (`xy` center point, `hw` width and height) and a binary segmentation mask. This document covers how to compile the bmodel and how to run it in a BM1684X (PCIe / SoC) environment.
 
-You can directly download the pre-compiled bmodel from the link below (F32, seq512, max_input_length 384, static, 256×256 images, works on both PCIe and SoC):
+You can directly download the pre-compiled bmodel from the links below (seq512, max_input_length 384, static, 256×256 images, works on both PCIe and SoC):
 
 ``` shell
 pip install dfss
-# BM1684X (PCIe / SoC, 1 dev) — approx. 2.5GB
+
+# BF16 (recommended, approx. 1.6GB) — FAttentionLseOp + FlexAttentionOp fused kernels
+python3 -m dfss --url=open@sophgo.com:/ext_model_information/LLM/LLM-TPU/falcon-perception_bf16_seq512_bm1684x_1dev_static_20260721_093418.bmodel
+
+# F32 full precision (approx. 2.5GB)
 python3 -m dfss --url=open@sophgo.com:/ext_model_information/LLM/LLM-TPU/falcon-perception_f32_seq512_bm1684x_1dev_static_20260716_185805.bmodel
 ```
 
+BF16 vs F32: model size ↓43%, device memory ↓39%, prefill 3.9× faster, decode 1.86× faster, accuracy loss <1% (coord/size bit-identical, mask ~0.4% difference).
+
 ## Model architecture
 
-Falcon-Perception is a referring-segmentation model based on a Falcon backbone (28 layers, dim 1024, 16 heads, 8 KV heads, GQA), deployed in full F32 precision:
+Falcon-Perception is a referring-segmentation model based on a Falcon backbone (28 layers, dim 1024, 16 heads, 8 KV heads, GQA), supporting both BF16 and F32 precision:
 
 - **Backbone LLM**: Falcon-style decoder (unweighted RMSNorm, squared-ReLU-gate FFN, 2D golden RoPE, attention sink). Compiled in two stages: prefill + decode (block_cache).
 - **Vision upsampling (anyup)**: takes the input image, the backbone's image-token hidden states, and a window mask; aggregates them through a Fourier encoder / key encoder / LFU / resblock, and outputs 256×256×256 hr_features.
@@ -49,13 +55,20 @@ source ./envsetup.sh
 #### 4. Compile the model to generate the bmodel
 
 ``` shell
+# BF16 (recommended, fused kernels, smaller and faster)
+llm_convert.py -m /workspace/falcon-perception \
+  -s 512 --max_input_length 384 -q bf16 -c bm1684x --max_pixels 256,256 \
+  -o /workspace/falcon-perception_bmodel
+
+# F32 full precision
 llm_convert.py -m /workspace/falcon-perception \
   -s 512 --max_input_length 384 -q f32 -c bm1684x --max_pixels 256,256 \
   -o /workspace/falcon-perception_bmodel
 ```
 
 Compilation parameter description:
-- `-q f32`: F32 full precision (no quantization).
+- `-q bf16`: BF16 precision (recommended, FAttentionLseOp fused self-attention + FlexAttentionOp fused cross-attention).
+- `-q f32`: F32 full precision (no quantization, hand-written attention decomposition).
 - `-s 512`: total KV cache length (SEQLEN).
 - `--max_input_length 384`: prefill input limit.
 - `--max_pixels 256,256`: maximum image size of 256×256 pixels.
@@ -100,18 +113,18 @@ python3 pipeline.py -m falcon-perception.bmodel -c ../config \
 ### Example run
 
 ``` shell
-python3 pipeline.py -m ../falcon-perception.bmodel -c ../config -q "the bed" --media_path test.jpg
-# [info] tokens=209  img_tokens=192
+python3 pipeline.py -m ../falcon-perception_bf16_flex.bmodel -c ../config -q "the bed" --media_path test.jpg
+# [info] tokens=210  img_tokens=192
 # Answer:
 # <|presence|>
 # [coord] x=0.3128 y=0.7928
-# [size] h=0.4089 w=0.6266
-# [seg] mask_pos=8525
+# [size] h=0.4034 w=0.6266
+# [seg] mask_pos=8639
 #
 # [emission] coord=1 size=1 seg=1  [detections] 1 (NMS kept 1/1)
-#   #0 xy=(0.313,0.793) hw=(0.409,0.627) mask_px=53804/309120
-#   visualization: ./test_the_bed_vis.jpg
-# FTL: 1.33 s   decode: 1.47 s   tokens: 4   TPS: 2.70
+#   #0 xy=(0.313,0.793) hw=(0.403,0.627) mask_px=54333/309120
+#   visualization: ./test_detect_the_bed_vis.jpg
+# FTL: 0.356 s   decode: 0.789 s   tokens: 4   TPS: 5.07
 ```
 
 The pipeline performs full post-processing on the raw 256×256 mask logits (aligned with HF `_postprocess_aux`):
@@ -133,14 +146,23 @@ The pipeline performs full post-processing on the raw 256×256 mask logits (alig
 
 ## Technical notes
 
-- **Quantization scheme**: F32 full precision, no quantization. The backbone, anyup, and all heads are F32.
+- **Quantization scheme**: BF16 (recommended) or F32. Under BF16, the backbone self-attention uses the FAttentionLseOp fused kernel (with fp32 lse + attention sink), and the AnyUp cross-attention uses the FlexAttentionOp fused kernel (non-square qk_d=32/v_d=64). F32 retains the hand-written attention decomposition path.
 - **Sampling**: fixed greedy (temperature=0); top-k / sampling / seed are not supported (HF `generate` has them, but this demo does not expose them).
 - **Batch**: batch inference is not supported; single image with a single query, processed serially.
 - **Context length**: seq512/max_input384 covers most scenarios at 256×256 (query ≤ ~700 characters, ≤ ~18 detections). Extreme scenarios require the user to recompile with larger settings.
 - **History**: multi-turn history is not supported (single image, single query).
 
+## Performance (BM1684X PCIe, 256×256, "the bed")
+
+| Metric | F32 | BF16 |
+|--------|-----|------|
+| bmodel size | 2.61 GB | 1.50 GB |
+| Device memory | 3363 MB | 2041 MB |
+| FTL (prefill) | 1.39 s | 0.356 s (3.9×↑) |
+| Decode | 1.47 s | 0.789 s (1.86×↑) |
+
 ## FAQ
 
 - **Supported resolutions**: up to 256×256 (`--max_pixels 256,256`). Changing the resolution requires recompiling the bmodel.
 - **Number of image tokens**: the image is resized to ≤256×256 while preserving the aspect ratio, with each side rounded to a multiple of 16 (patch_size=16, merge=1); `image_tokens = (H_res/16) × (W_res/16)`. Example: 640×483 → 256×192 → 16×12 = 192 tokens; a square 256×256 image hits the upper limit of 256 tokens. Adding template tokens plus the query gives the prefill length.
-- **Device memory**: approx. 3.3GB (DevMem 3363/14678 MB on BM1684X).
+- **Device memory**: BF16 approx. 2.0GB (DevMem 2041/14678 MB); F32 approx. 3.3GB (DevMem 3363/14678 MB).

--- a/models/Falcon-Perception/python_demo/chat.cpp
+++ b/models/Falcon-Perception/python_demo/chat.cpp
@@ -33,10 +33,12 @@
 //   anyup            : [1,3,256,256] f32, [1,1024,16,16] f32 -> [1,256,256,256] f32
 //                      (window_mask baked into bmodel as a const weight)
 //
-// Image-patch projection + masked_scatter is done host-side (pipeline);
-// forward_first receives the assembled input_states. coord/size Fourier 回灌
-// is done via coord_encoder/size_encoder bmodels whose output overrides the
-// embedded token in forward_next (fourier_emb arg).
+// Image-patch projection is done host-side (pipeline); forward_first embeds
+// the tokens on device, then scatters the projected patch features directly
+// into block_0's input mem at the img-token rows (partial s2d by offset) — the
+// full [MAX_INPUT_LENGTH, HIDDEN] embedding never leaves the device. coord/size
+// Fourier 回灌 is done via coord_encoder/size_encoder bmodels whose output
+// overrides the embedded token in forward_next (fourier_emb arg).
 
 #include "bmruntime_interface.h"
 #include "memory.h"
@@ -91,9 +93,15 @@ public:
   void init(int devid, std::string model_path);
   void deinit();
   ArrayFloat forward_embed(ArrayInt const &tokens);
-  int forward_first(ArrayFloat const &input_states, ArrayInt const &position_ids,
+  // tokens: token ids [MAX_INPUT_LENGTH] (right-padded). img_feats/img_pos:
+  // projected image-patch features [M,HIDDEN] and their token row positions [M]
+  // (the img-token slots). forward_first embeds tokens on device, scatters
+  // img_feats into block_0's input mem at img_pos rows, then runs prefill —
+  // the full embedding never round-trips through the host.
+  int forward_first(ArrayInt const &tokens, ArrayInt const &position_ids,
                     ArrayFloat const &golden_cos, ArrayFloat const &golden_sin,
-                    ArrayFloat const &attention_mask, int token_length);
+                    ArrayFloat const &attention_mask, int token_length,
+                    ArrayFloat const &img_feats, ArrayInt const &img_pos);
   // fourier_emb: if non-empty [1,HIDDEN] embedding, overrides the embedded token
   // (回灌: coord/size token's embedding replaced by Fourier(xy/hw)).
   int forward_next(int prev_token, ArrayInt const &position_ids,
@@ -295,29 +303,63 @@ ArrayFloat FalconPerception::forward_embed(ArrayInt const &tokens) {
   return out;
 }
 
-int FalconPerception::forward_first(ArrayFloat const &input_states,
+int FalconPerception::forward_first(ArrayInt const &tokens,
                                     ArrayInt const &position_ids,
                                     ArrayFloat const &golden_cos,
                                     ArrayFloat const &golden_sin,
                                     ArrayFloat const &attention_mask,
-                                    int tok_len) {
+                                    int tok_len,
+                                    ArrayFloat const &img_feats,
+                                    ArrayInt const &img_pos) {
   token_length = tok_len;
+  auto p_tok = tokens.request();
   auto p_pos = position_ids.request();
   auto p_gcos = golden_cos.request();
   auto p_gsin = golden_sin.request();
   auto p_mask = attention_mask.request();
-  auto p_in = input_states.request();
+  auto p_feats = img_feats.request();
+  auto p_ipos = img_pos.request();
 
-  // run prefill blocks
+  // 1) token embedding on device (no host round-trip). The projected image-
+  //    patch features are scattered directly into block_0's input mem at the
+  //    img-token rows below, so the full [MAX_INPUT_LENGTH, HIDDEN] embedding
+  //    never leaves the device.
+  auto &embed_in = net_embed->stages[0].input_mems[0];
+  auto &embed_out = net_embed->stages[0].output_mems[0];
+  bm_memcpy_s2d(bm_handle, embed_in, p_tok.ptr);
+  net_launch(net_embed);
+
+  // 2) place embedding into block_0's input mem (d2d). embed_out and block_0's
+  //    input mem may alias under BM_RUNTIME_SHARE_MEM (then this is a harmless
+  //    self-copy). net_launch above synced, so embed_out is settled.
+  auto &blk0_in = net_blocks[0]->stages[0].input_mems[0];
+  int embed_bytes = MAX_INPUT_LENGTH * HIDDEN_SIZE * sizeof(float);
+  bm_memcpy_d2d_byte(bm_handle, blk0_in, 0, embed_out, 0, embed_bytes);
+
+  // 3) scatter img-patch features into the img-token rows (partial s2d by row
+  //    offset). Overwrites the placeholder img-token embeddings with the
+  //    projected patch features, matching the old host-side masked_scatter.
+  int M = p_ipos.size;
+  int row_bytes = HIDDEN_SIZE * sizeof(float);
+  auto ipos_ptr = static_cast<int *>(p_ipos.ptr);
+  auto feats_ptr = static_cast<float *>(p_feats.ptr);
+  for (int m = 0; m < M; m++) {
+    int row = ipos_ptr[m];
+    auto dst = bm_mem_from_device(
+        blk0_in.u.device.device_addr + (uint64_t)row * row_bytes, row_bytes);
+    bm_memcpy_s2d(bm_handle, dst,
+                  (void *)(feats_ptr + (int64_t)m * HIDDEN_SIZE));
+  }
+
+  // 4) run prefill blocks
   bm_device_mem_t out_mem;
   for (int idx = 0; idx < NUM_LAYERS; idx++) {
     auto &net = net_blocks[idx];
     std::vector<bm_tensor_t> in_tensors(net->input_num);
     std::vector<bm_tensor_t> out_tensors(net->output_num);
-    // input_states: first block from host, later blocks from previous output
-    if (idx == 0) {
-      bm_memcpy_s2d(bm_handle, net->stages[0].input_mems[0], p_in.ptr);
-    } else {
+    // block_0 input already filled (embedding + img scatter) above; later
+    // blocks read the previous block's output.
+    if (idx > 0) {
       bm_memcpy_d2d_byte(bm_handle, net->stages[0].input_mems[0], 0, out_mem, 0,
                          token_length * HIDDEN_SIZE * sizeof(float));
     }
@@ -576,7 +618,11 @@ PYBIND11_MODULE(chat, m) {
       .def("init", &FalconPerception::init)
       .def("deinit", &FalconPerception::deinit)
       .def("forward_embed", &FalconPerception::forward_embed)
-      .def("forward_first", &FalconPerception::forward_first)
+      .def("forward_first", &FalconPerception::forward_first,
+           py::arg("tokens"), py::arg("position_ids"), py::arg("golden_cos"),
+           py::arg("golden_sin"), py::arg("attention_mask"),
+           py::arg("token_length"), py::arg("img_feats"),
+           py::arg("img_pos"))
       .def("forward_next", &FalconPerception::forward_next,
            py::arg("prev_token"),
            py::arg("position_ids"), py::arg("golden_cos"), py::arg("golden_sin"),

--- a/models/Falcon-Perception/python_demo/pipeline.py
+++ b/models/Falcon-Perception/python_demo/pipeline.py
@@ -114,16 +114,18 @@ class FalconPerception():
         return batch
 
     # ---------------------------------------------------- host-side input states
-    def build_input_states(self, batch, embedding):
-        """embedding: [512,1024] token embeddings (pad at the tail).
-        Scatter img_projector(patches) into the img-token positions."""
+    def build_img_injection(self, batch):
+        """Compute projected image-patch features [M,1024] and their token row
+        positions [M]. chat.cpp scatters these directly into block_0's input
+        mem at the img-token rows (partial s2d by offset), so the full
+        [512,1024] embedding never round-trips through the host."""
         tokens = batch["tokens"][0]                      # [L]
         L = tokens.shape[0]
-        input_states = embedding.copy()                  # [512,1024]
         pixel_values = batch["pixel_values"]             # [N,1,H,W,3]
         pixel_mask = batch["pixel_mask"]                 # [N,H,W]
         if pixel_values is None:
-            return input_states, L
+            return (np.zeros((0, self.hidden), np.float32),
+                    np.zeros((0,), np.int32), L)
         c = self.config
         pixel_patches = E.rearrange(
             pixel_values,
@@ -155,11 +157,10 @@ class FalconPerception():
         padded_tokens = np.concatenate(
             [tokens.numpy().astype(np.int64),
              np.full(pad_len, self.ID_PAD, dtype=np.int64)])
-        img_pos = np.where(padded_tokens == self.ID_IMG)[0]
+        img_pos = np.where(padded_tokens == self.ID_IMG)[0].astype(np.int32)
         assert img_pos.shape[0] == valid_feats.shape[0], (
             f"img tokens {img_pos.shape[0]} != patches {valid_feats.shape[0]}")
-        input_states[img_pos] = valid_feats
-        return input_states, L
+        return valid_feats.astype(np.float32), img_pos, L
 
     # ---------------------------------------------------------- golden 2D RoPE
     def build_golden_cos_sin(self, batch, L):
@@ -419,22 +420,20 @@ class FalconPerception():
         print(f"\n[info] tokens={L}  img_tokens={(tokens.numpy()==self.ID_IMG).sum()}")
         t0 = time.time()
 
-        # 1) token embedding (pad to 512 inside forward_embed)
-        embedding = self.model.forward_embed(
-            tokens.numpy().astype(np.int32))            # [512,1024] numpy
-
-        # 2) assemble input_states (scatter img patches) + golden cos/sin + mask
-        input_states, L = self.build_input_states(batch, embedding)
+        # 1) img-patch injection (projected features + token row positions).
+        #    The token embedding stays on device; forward_first scatters these
+        #    into block_0's input mem at the img-token rows.
+        img_feats, img_pos, L = self.build_img_injection(batch)
         pos_t = batch["pos_t"][0].numpy().astype(np.int32)     # [L]
         pos_pad = np.zeros(self.MAX_INPUT_LENGTH, dtype=np.int32)
         pos_pad[:L] = pos_t
         gcos, gsin = self.build_golden_cos_sin(batch, L)
         attn_mask = self.build_prefill_mask(batch, L)
 
-        # 3) prefill
+        # 2) prefill (embed + img scatter + blocks, all on device)
         token = self.model.forward_first(
-            input_states.astype(np.float32), pos_pad, gcos, gsin,
-            attn_mask, L)
+            tokens.numpy().astype(np.int32), pos_pad, gcos, gsin,
+            attn_mask, L, img_feats, img_pos)
         self.max_posid = int(pos_t[-1])
         t1 = time.time()
         # Don't decode the first token here — the decode loop below dispatches


### PR DESCRIPTION
- README: add bf16 bmodel download link, performance comparison table (bf16 vs f32: prefill 3.9x, decode 1.86x, DevMem -39%, size -43%)
- chat.cpp: forward_first keeps token embedding on device, scatters projected img-patch features into block_0 input mem by row offset (eliminates 4MB host round-trip per prefill)
- pipeline.py: build_img_injection replaces build_input_states, returns projected features + token positions instead of assembled input_states