### PR TITLE
feat: support non-square image shapes (e.g. 320x192 for 16:9)

### DIFF
--- a/models/Falcon-Perception/README.md
+++ b/models/Falcon-Perception/README.md
@@ -60,6 +60,11 @@ llm_convert.py -m /workspace/falcon-perception \
   -s 512 --max_input_length 384 -q bf16 -c bm1684x --max_pixels 256,256 \
   -o /workspace/falcon-perception_bmodel
 
+# BF16 non-square example (320×192)
+llm_convert.py -m /workspace/falcon-perception \
+  -s 512 --max_input_length 384 -q bf16 -c bm1684x --max_pixels 320,192 \
+  -o /workspace/falcon-perception_bmodel
+
 # F32 full precision
 llm_convert.py -m /workspace/falcon-perception \
   -s 512 --max_input_length 384 -q f32 -c bm1684x --max_pixels 256,256 \
@@ -71,9 +76,9 @@ Compilation parameter description:
 - `-q f32`: F32 full precision (no quantization, hand-written attention decomposition).
 - `-s 512`: total KV cache length (SEQLEN).
 - `--max_input_length 384`: prefill input limit.
-- `--max_pixels 256,256`: maximum image size of 256×256 pixels.
+- `--max_pixels H,W`: maximum image size in pixels. Supports non-square shapes (both H and W must be multiples of 16), e.g. `320,192`.
 - `-c bm1684x`: target chip.
-- Static compilation (fixed shapes). For extra-long queries or scenarios with more than ~16 detections, you need to increase `-s`/`--max_input_length` and recompile yourself.
+- Static compilation (fixed shapes). The bmodel is locked to the compiled `--max_pixels` shape. For extra-long queries or scenarios with more than ~16 detections, you need to increase `-s`/`--max_input_length` and recompile yourself.
 
 Output: `falcon-perception_f32_seq512_bm1684x_1dev_static_<ts>.bmodel` (approx. 2.5GB, 64 nets).
 
@@ -162,6 +167,6 @@ The pipeline performs full post-processing on the raw 256×256 mask logits (alig
 
 ## FAQ
 
-- **Supported resolutions**: up to 256×256 (`--max_pixels 256,256`). Changing the resolution requires recompiling the bmodel.
-- **Number of image tokens**: the image is resized to ≤256×256 while preserving the aspect ratio, with each side rounded to a multiple of 16 (patch_size=16, merge=1); `image_tokens = (H_res/16) × (W_res/16)`. Example: 640×483 → 256×192 → 16×12 = 192 tokens; a square 256×256 image hits the upper limit of 256 tokens. Adding template tokens plus the query gives the prefill length.
-- **Device memory**: BF16 approx. 2.0GB (DevMem 2041/14678 MB); F32 approx. 3.3GB (DevMem 3363/14678 MB).
+- **Supported resolutions**: the bmodel is statically compiled with `--max_pixels H,W` (both must be multiples of 16). Non-square shapes are supported. Changing the shape requires recompiling the bmodel and updating `pipeline.py` `process()` to pass matching `min_dimension`, `max_dimension_h`, `max_dimension_w`.
+- **Number of image tokens**: the image is resized to fit within max_H × max_W while preserving the aspect ratio, with each side rounded to a multiple of 16 (patch_size=16, merge=1); `image_tokens = (H_res/16) × (W_res/16)`. Example (256×256): 640×483 → 256×192 → 16×12 = 192 tokens. Example (320×192): 640×360 → 320×180 → 20×11 = 220 tokens. Adding template tokens plus the query gives the prefill length.
+- **Device memory**: BF16 256×256 approx. 2.0GB; BF16 320×192 approx. 2.0GB; F32 256×256 approx. 3.3GB.

--- a/models/Falcon-Perception/config/processing_falcon_perception.py
+++ b/models/Falcon-Perception/config/processing_falcon_perception.py
@@ -378,7 +378,8 @@ def process_batch(
     image_prompt_pairs,
     max_length,
     min_dimension,
-    max_dimension,
+    max_dimension_h,
+    max_dimension_w,
     patch_size=16,
     merge_size=1,
 ):
@@ -389,11 +390,18 @@ def process_batch(
     all_input_ids = []
     all_selected_images = []
     processor_local = ImageProcessor(patch_size, merge_size)
+    max_dimension = max(max_dimension_h, max_dimension_w)
 
     for img_input, prompt in image_prompt_pairs:
         img = load_image(img_input)
         if img is not None:
             img = resize_image_if_necessary(img, min_dimension, max_dimension)
+            # Ensure both dimensions fit within max_dimension_h x max_dimension_w
+            # (resize_image_if_necessary only constrains the longest side).
+            w, h = img.size
+            if w > max_dimension_w or h > max_dimension_h:
+                scale = min(max_dimension_w / w, max_dimension_h / h)
+                img = img.resize((int(w * scale), int(h * scale)))
         images = processor_local.preprocess(images=[img] if img else [])
         input_ids, selected_images = tokenize_inputs(
             prompt, images, tokenizer, config, patch_size, merge_size, max_length,
@@ -406,7 +414,7 @@ def process_batch(
         all_input_ids, batch_first=True, padding_value=pad_token_id, padding_side="left",
     )
 
-    processed = processor_local.batch_images_with_mask(all_selected_images, max_dimension, max_dimension)
+    processed = processor_local.batch_images_with_mask(all_selected_images, max_dimension_h, max_dimension_w)
     assert processed is not None
 
     pos_t, pos_hw = get_pos_thw(

--- a/models/Falcon-Perception/python_demo/pipeline.py
+++ b/models/Falcon-Perception/python_demo/pipeline.py
@@ -92,7 +92,7 @@ class FalconPerception():
         self.img_projector = data["img_projector_weight"].astype(np.float32)  # [1024,768] numpy
         self.freqs_cis_golden = torch.from_numpy(
             data["freqs_cis_golden"].astype(np.float32))         # [16,32,2]
-        # AnyUp window attention mask is geometry-only (static 256x256), so it
+        # AnyUp window attention mask is geometry-only (static HxW), so it
         # is baked into the anyup bmodel as a const weight — not needed here.
 
     # ------------------------------------------------------------------ process
@@ -108,7 +108,7 @@ class FalconPerception():
         batch = self.process_batch(
             self.tokenizer, self.config, [(image_path, prompt)],
             max_length=self.MAX_INPUT_LENGTH,
-            min_dimension=256, max_dimension=256,
+            min_dimension=192, max_dimension_h=320, max_dimension_w=192,
             patch_size=self.patch_size, merge_size=self.merge_size,
         )
         return batch
@@ -239,33 +239,33 @@ class FalconPerception():
 
     # -------------------------------------------------------- anyup + heads
     def build_anyup_inputs(self, batch, h_BSD):
-        """images [1,3,256,256], lr_tokens [1,1024,16,16] (gather img-token
-        hidden PRE conv_segm into the full 16x16 grid, invalid patches = 0).
+        """images [1,3,H,W], lr_tokens [1,1024,h,w] (gather img-token
+        hidden PRE conv_segm into the full hxw grid, invalid patches = 0).
         Mirrors HF gather_img_tokens. (window_mask is baked into the bmodel.)"""
         c = self.config
         ph = pw = c.spatial_patch_size                         # 16
         tokens = batch["tokens"][0].numpy().astype(np.int64)
         img_pos = np.where(tokens == self.ID_IMG)[0]           # [M] valid img tokens
         valid = h_BSD[img_pos].astype(np.float32)              # [M,1024] in (h,w) order
-        # itok grid mask [16,16] from pixel_mask [N,1,H,W] (or [N,H,W])
+        # itok grid mask [h,w] from pixel_mask [N,1,H,W] (or [N,H,W])
         pm = batch["pixel_mask"]
         if pm.ndim == 4:
             pm = pm[:, 0]                                      # [N,H,W]
         itok = E.reduce(pm.numpy().astype(bool),
                         "n (h ph) (w pw) -> h w", reduction="any",
-                        ph=ph, pw=pw)                          # [16,16]
+                        ph=ph, pw=pw)                          # [h,w]
         grid = np.zeros((itok.shape[0], itok.shape[1], self.hidden),
-                        dtype=np.float32)                      # [16,16,1024]
+                        dtype=np.float32)                      # [h,w,1024]
         grid[itok] = valid                                     # scatter valid, rest 0
-        lr_tokens = grid.transpose(2, 0, 1)[None].astype(np.float32)  # [1,1024,16,16]
+        lr_tokens = grid.transpose(2, 0, 1)[None].astype(np.float32)  # [1,1024,h,w]
         pv = batch["pixel_values"]                             # [N,1,H,W,3]
-        images = pv[0, 0].numpy().transpose(2, 0, 1)[None].astype(np.float32)  # [1,3,256,256]
+        images = pv[0, 0].numpy().transpose(2, 0, 1)[None].astype(np.float32)  # [1,3,H,W]
         return images, lr_tokens
 
     def run_anyup(self, batch, h_BSD):
         images, lr_tokens = self.build_anyup_inputs(batch, h_BSD)
         hr = np.array(self.model.forward_anyup(images, lr_tokens),
-                      dtype=np.float32)                       # [1,256,256,256]
+                      dtype=np.float32)                       # [1,256,H,W]
         return hr
 
     def decode_coord(self, h_last, existing_coords):
@@ -301,19 +301,20 @@ class FalconPerception():
         return hw, fourier
 
     def decode_seg(self, h_last, hr_features):
-        """h_last [1024], hr_features [1,256,256,256] -> mask logits [256,256]."""
+        """h_last [1024], hr_features [1,256,H,W] -> mask logits [H,W]."""
         seg_vec = np.array(self.model.forward_seg(
             h_last.astype(np.float32)), dtype=np.float32).reshape(1, self.segm_out_dim)
         k = self.max_segm_tokens
         seg_pad = np.zeros((k, self.segm_out_dim), dtype=np.float32)
         seg_pad[0] = seg_vec[0]
-        hr = hr_features.astype(np.float32)                    # [1,256,256,256]
+        hr = hr_features.astype(np.float32)                    # [1,256,H,W]
+        mh, mw = hr.shape[2], hr.shape[3]
         mask = np.array(self.model.forward_mask(hr, seg_pad),
-                        dtype=np.float32).reshape(k, 256, 256)
-        return mask[0]                                         # [256,256]
+                        dtype=np.float32).reshape(k, mh, mw)
+        return mask[0]                                         # [H,W]
 
     def _mask_to_binary(self, mask_logits, pixel_mask_hw, orig_hw, threshold=0.5):
-        """[256,256] logits (processed space) -> binary [orig_h, orig_w] mask.
+        """[H,W] logits (processed space) -> binary [orig_h, orig_w] mask.
         Mirrors HF _postprocess_aux: crop to pixel_mask active region, bilinear
         resize to original size, sigmoid > threshold."""
         import torch.nn.functional as F
@@ -447,7 +448,7 @@ class FalconPerception():
                               dtype=np.float32).reshape(self.MAX_INPUT_LENGTH,
                                                         self.hidden)
         h_last = h_BSD_full[L - 1].copy()                     # hidden that emitted `token`
-        hr_features = self.run_anyup(batch, h_BSD_full[:L])   # [1,256,256,256]
+        hr_features = self.run_anyup(batch, h_BSD_full[:L])   # [1,256,H,W]
 
         # 4) decode loop with coord/size/seg head dispatch + Fourier feedback
         tok_num = 0


### PR DESCRIPTION
- processor: process_batch accepts separate max_dimension_h/w, pads non-square, adds post-resize constraint to fit both dimensions
- pipeline: decode_seg uses dynamic H/W from hr_features instead of hardcoded 256; process() passes matching dimensions
- README: add 320x192 compile example, document non-square support