### PR TITLE
fix: rebind history KV inputs to past_key/past_value in decode

### DIFF
--- a/models/Qwen3/cpp_demo/chat.cpp
+++ b/models/Qwen3/cpp_demo/chat.cpp
@@ -393,8 +393,8 @@ void Qwen::net_launch_decode(int idx, int kv_offset, bm_device_mem_t &input_mem,
   // auto &in0_mem = net_blocks_cache[idx]->stages[stage_idx].input_mems[0];
   auto &in1_mem = net_blocks_cache[idx]->stages[stage_idx].input_mems[1];
   auto &in2_mem = net_blocks_cache[idx]->stages[stage_idx].input_mems[2];
-  auto &in3_mem = net_blocks_cache[idx]->stages[stage_idx].input_mems[3];
-  auto &in4_mem = net_blocks_cache[idx]->stages[stage_idx].input_mems[4];
+  // auto &in3_mem = net_blocks_cache[idx]->stages[stage_idx].input_mems[3];
+  // auto &in4_mem = net_blocks_cache[idx]->stages[stage_idx].input_mems[4];
   auto &out0_mem = net_blocks_cache[idx]->stages[stage_idx].output_mems[0];
   // ===== prepare input tensors =====
   bmrt_tensor_with_device(&in_tensors[0], input_mem, net->input_dtypes[0],
@@ -414,10 +414,19 @@ void Qwen::net_launch_decode(int idx, int kv_offset, bm_device_mem_t &input_mem,
         &in_tensors[2], net_blocks_cache[0]->stages[stage_idx].input_mems[2],
         net->input_dtypes[2], net->stages[stage_idx].input_shapes[2]);
   }
-  bmrt_tensor_with_device(&in_tensors[3], in3_mem, net->input_dtypes[3],
-                          net->stages[stage_idx].input_shapes[3]);
-  bmrt_tensor_with_device(&in_tensors[4], in4_mem, net->input_dtypes[4],
-                          net->stages[stage_idx].input_shapes[4]);
+  // The real KV lives in past_key/past_value; rebind history inputs to them
+  // (only stage 0's input_mems is aliased there).
+  int stage_capacity = net->stages[stage_idx].input_shapes[3].dims[1];
+  bmrt_tensor_with_device(
+      &in_tensors[3],
+      bm_mem_from_device(past_key[idx].u.device.device_addr,
+                         stage_capacity * kv_bytes),
+      net->input_dtypes[3], net->stages[stage_idx].input_shapes[3]);
+  bmrt_tensor_with_device(
+      &in_tensors[4],
+      bm_mem_from_device(past_value[idx].u.device.device_addr,
+                         stage_capacity * kv_bytes),
+      net->input_dtypes[4], net->stages[stage_idx].input_shapes[4]);
   // ===== prepare output tensors =====
   bmrt_tensor_with_device(&out_tensors[0], out0_mem, net->output_dtypes[0],
                           net->stages[stage_idx].output_shapes[0]);

--- a/models/Qwen3_5/cpp_demo/chat.cpp
+++ b/models/Qwen3_5/cpp_demo/chat.cpp
@@ -143,6 +143,13 @@ void Qwen3_5::net_launch_decode(int idx, int kv_offset,
   bm_memcpy_s2d(bm_handle, in_tensors[1].device_mem, (void *)pos_id);
   bm_memcpy_s2d(bm_handle, in_tensors[2].device_mem,
                 (void *)attention_mask.data());
+  // The real KV lives in past_key/past_value; rebind history inputs to them
+  // (only stage 0's input_mems is aliased there).
+  int stage_capacity = net->stages[stage_idx].input_shapes[3].dims[1];
+  in_tensors[3].device_mem = bm_mem_from_device(
+      past_key[idx].u.device.device_addr, stage_capacity * KV_BYTES);
+  in_tensors[4].device_mem = bm_mem_from_device(
+      past_value[idx].u.device.device_addr, stage_capacity * KV_BYTES);
   out_tensors[1].device_mem = bm_mem_from_device(
       past_key[idx].u.device.device_addr + kv_offset, KV_BYTES);
   out_tensors[2].device_mem = bm_mem_from_device(

--- a/models/Qwen3_5/cpp_demo_pp/block.cpp
+++ b/models/Qwen3_5/cpp_demo_pp/block.cpp
@@ -30,6 +30,13 @@ void Block::net_launch_decode(int local_idx, int kv_offset, const int *pos_id,
   bm_memcpy_s2d(bm_handle, in_tensors[1].device_mem, (void *)pos_id);
   bm_memcpy_s2d(bm_handle, in_tensors[2].device_mem,
                 (void *)attention_mask.data());
+  // The real KV lives in past_key/past_value; rebind history inputs to them
+  // (only stage 0's input_mems is aliased there).
+  int stage_capacity = net->stages[stage_idx].input_shapes[3].dims[1];
+  in_tensors[3].device_mem = bm_mem_from_device(
+      past_key[local_idx].u.device.device_addr, stage_capacity * KV_BYTES);
+  in_tensors[4].device_mem = bm_mem_from_device(
+      past_value[local_idx].u.device.device_addr, stage_capacity * KV_BYTES);
   out_tensors[1].device_mem = bm_mem_from_device(
       past_key[local_idx].u.device.device_addr + kv_offset, KV_BYTES);
   out_tensors[2].device_mem = bm_mem_from_device(

--- a/models/Qwen3_5/cpp_demo_share_prompt/chat.cpp
+++ b/models/Qwen3_5/cpp_demo_share_prompt/chat.cpp
@@ -143,6 +143,13 @@ void Qwen3_5::net_launch_decode(int idx, int kv_offset,
   bm_memcpy_s2d(bm_handle, in_tensors[1].device_mem, (void *)pos_id);
   bm_memcpy_s2d(bm_handle, in_tensors[2].device_mem,
                 (void *)attention_mask.data());
+  // The real KV lives in past_key/past_value; rebind history inputs to them
+  // (only stage 0's input_mems is aliased there).
+  int stage_capacity = net->stages[stage_idx].input_shapes[3].dims[1];
+  in_tensors[3].device_mem = bm_mem_from_device(
+      past_key[idx].u.device.device_addr, stage_capacity * KV_BYTES);
+  in_tensors[4].device_mem = bm_mem_from_device(
+      past_value[idx].u.device.device_addr, stage_capacity * KV_BYTES);
   out_tensors[1].device_mem = bm_mem_from_device(
       past_key[idx].u.device.device_addr + kv_offset, KV_BYTES);
   out_tensors[2].device_mem = bm_mem_from_device(

--- a/models/Qwen3_5/python_demo/chat.cpp
+++ b/models/Qwen3_5/python_demo/chat.cpp
@@ -177,6 +177,13 @@ void Qwen3_5::net_launch_decode(int idx, int kv_offset,
   bm_memcpy_s2d(bm_handle, in_tensors[1].device_mem, (void *)pos_id);
   bm_memcpy_s2d(bm_handle, in_tensors[2].device_mem,
                 (void *)attention_mask.data());
+  // The real KV lives in past_key/past_value; rebind history inputs to them
+  // (only stage 0's input_mems is aliased there).
+  int stage_capacity = net->stages[stage_idx].input_shapes[3].dims[1];
+  in_tensors[3].device_mem = bm_mem_from_device(
+      past_key[idx].u.device.device_addr, stage_capacity * KV_BYTES);
+  in_tensors[4].device_mem = bm_mem_from_device(
+      past_value[idx].u.device.device_addr, stage_capacity * KV_BYTES);
   out_tensors[1].device_mem = bm_mem_from_device(
       past_key[idx].u.device.device_addr + kv_offset, KV_BYTES);
   out_tensors[2].device_mem = bm_mem_from_device(

--- a/models/Qwen3_VL/cpp_demo/chat.cpp
+++ b/models/Qwen3_VL/cpp_demo/chat.cpp
@@ -156,6 +156,13 @@ void Qwen3_VL::net_launch_decode(int idx, int kv_offset,
       past_key[idx].u.device.device_addr + kv_offset, KV_BYTES);
   out_tensors[2].device_mem = bm_mem_from_device(
       past_value[idx].u.device.device_addr + kv_offset, KV_BYTES);
+  // The real KV lives in past_key/past_value; rebind history inputs to them
+  // (only stage 0's input_mems is aliased there).
+  int stage_capacity = net->stages[stage_idx].input_shapes[3].dims[1];
+  in_tensors[3].device_mem = bm_mem_from_device(
+      past_key[idx].u.device.device_addr, stage_capacity * KV_BYTES);
+  in_tensors[4].device_mem = bm_mem_from_device(
+      past_value[idx].u.device.device_addr, stage_capacity * KV_BYTES);
 
   // ===== launch =====
   net_launch(net, in_tensors, out_tensors);

--- a/models/Qwen3_VL/python_demo/chat.cpp
+++ b/models/Qwen3_VL/python_demo/chat.cpp
@@ -187,6 +187,13 @@ void Qwen3_VL::net_launch_decode(int idx, int kv_offset,
     in_tensors[2].device_mem =
         net_blocks_cache[0]->stages[stage_idx].input_mems[2];
   }
+  // The real KV lives in past_key/past_value; rebind history inputs to them
+  // (only stage 0's input_mems is aliased there).
+  int stage_capacity = net->stages[stage_idx].input_shapes[3].dims[1];
+  in_tensors[3].device_mem = bm_mem_from_device(
+      past_key[idx].u.device.device_addr, stage_capacity * KV_BYTES);
+  in_tensors[4].device_mem = bm_mem_from_device(
+      past_value[idx].u.device.device_addr, stage_capacity * KV_BYTES);
   out_tensors[1].device_mem = bm_mem_from_device(
       past_key[idx].u.device.device_addr + kv_offset, KV_BYTES);
   out_tensors[2].device_mem = bm_mem_from_device(


### PR DESCRIPTION
select_decode_stage() (d52bb66) can return a non-zero stage index when history_length exceeds smaller stage capacities. However, only stage 0's input_mems[3]/[4] is aliased to past_key/past_value — non-zero stages have separate empty buffers there. Attention reads garbage history, producing token 0 (all '!').

Fix: in net_launch_decode, rebind in_tensors[3]/[4] to past_key/ past_value at the selected stage's capacity via bm_mem_from_device (zero-copy view). The real KV lives in past_key/past_value regardless of which stage runs; the attention_mask masks out positions beyond history_length so the tail is irrelevant.

Affected demos: Qwen3 cpp, Qwen3.5 python/cpp/cpp_share_prompt/cpp_pp, Qwen3_VL python/cpp.